### PR TITLE
fixing support for steal < 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "donejs",
     "donejs-plugin"
   ],
-  "steal": {
+  "system": {
     "main": "can-make-rest",
     "configDependencies": [
       "live-reload"


### PR DESCRIPTION
closes https://github.com/canjs/can-make-rest/issues/9.